### PR TITLE
Update logic for if address is in wallet or not

### DIFF
--- a/api/src/main/kotlin/info/blockchain/challenge/api/MultiAddress.kt
+++ b/api/src/main/kotlin/info/blockchain/challenge/api/MultiAddress.kt
@@ -38,8 +38,13 @@ class Transaction(
 
 class TXO(
         @SerializedName("addr")
-        val address: String,
+        val address: String = "",
 
         @SerializedName("xpub")
-        val xpub: Any?
+        val xpub: Xpub? = null
+)
+
+class Xpub(
+        @SerializedName("m")
+        val m: String = ""
 )

--- a/app/src/main/java/info/blockchain/challenge/Mappings.kt
+++ b/app/src/main/java/info/blockchain/challenge/Mappings.kt
@@ -2,34 +2,35 @@ package info.blockchain.challenge
 
 import info.blockchain.challenge.api.Result
 import info.blockchain.challenge.api.TXO
+import info.blockchain.challenge.api.Transaction
 import info.blockchain.challenge.ui.viewmodel.AccountCardViewModel
 import info.blockchain.challenge.ui.viewmodel.CardViewModel
 import info.blockchain.challenge.ui.viewmodel.TransactionCardViewModel
 import info.blockchain.challenge.ui.viewmodel.satoshiToBtc
 import java.util.*
 
-// Note: These aliases make the code clearer due to the name clash. Few places will need both, and this prevents us
-// resorting to smurf-naming like: info.blockchain.challenge.api.TransactionApi
-typealias ApiTransaction = info.blockchain.challenge.api.Transaction
+fun Result.mapToCardViewModels(mapper: Mapper) = mapper.mapToCardViewModels(this)
 
-typealias ViewModelTransaction = TransactionCardViewModel
+fun Transaction.mapToViewModel(mapper: Mapper) = mapper.mapToViewModel(this)
 
-fun ApiTransaction.mapToViewModel() =
-        ViewModelTransaction(
-                value = this.result.satoshiToBtc(),
-                address = this.outputs.findFirstNonWalletAddress(),
-                date = Date(this.timeStamp * 1000)
-        )
+class Mapper(private val walletXpub: String) {
+    fun mapToViewModel(transaction: Transaction) =
+            TransactionCardViewModel(
+                    value = transaction.result.satoshiToBtc(),
+                    address = transaction.outputs.findFirstNonWalletAddress(),
+                    date = Date(transaction.timeStamp * 1000)
+            )
 
-fun Result.mapToCardViewModels(): List<CardViewModel> =
-        listOf(mapToAccountViewModel()) + this.transactions.map(ApiTransaction::mapToViewModel)
+    fun mapToCardViewModels(result: Result): List<CardViewModel> =
+            listOf(result.mapToAccountViewModel()) + result.transactions.map { mapToViewModel(it) }
 
-private fun Result.mapToAccountViewModel() = AccountCardViewModel(this.wallet.finalBalance.satoshiToBtc())
+    private fun Result.mapToAccountViewModel() = AccountCardViewModel(this.wallet.finalBalance.satoshiToBtc())
 
-private fun List<TXO>.findFirstNonWalletAddress() =
-        this.firstNonWalletTransactionOutput()?.address ?: ""
+    private fun List<TXO>.findFirstNonWalletAddress() =
+            this.firstNonWalletTransactionOutput()?.address ?: ""
 
-private fun List<TXO>.firstNonWalletTransactionOutput() =
-        this.firstOrNull { !it.isWalletAddress() }
+    private fun List<TXO>.firstNonWalletTransactionOutput() =
+            this.firstOrNull { !it.isWalletAddress() }
 
-private fun TXO.isWalletAddress() = this.xpub != null
+    private fun TXO.isWalletAddress() = this.xpub?.m == walletXpub
+}

--- a/app/src/main/java/info/blockchain/challenge/ui/WalletMviDialog.kt
+++ b/app/src/main/java/info/blockchain/challenge/ui/WalletMviDialog.kt
@@ -1,8 +1,8 @@
 package info.blockchain.challenge.ui
 
+import info.blockchain.challenge.Mapper
 import info.blockchain.challenge.R
 import info.blockchain.challenge.api.MultiAddress
-import info.blockchain.challenge.api.Result
 import info.blockchain.challenge.mapToCardViewModels
 import info.blockchain.challenge.ui.viewmodel.CardViewModel
 import info.blockchain.challenge.ui.viewmodel.ErrorCardViewModel
@@ -56,7 +56,7 @@ class WalletMviDialog(
             .map { it.xpub }
             .flatMapSingle { xpub ->
                 service.multiaddr(xpub)
-                        .map(Result::mapToCardViewModels)
+                        .map { it.mapToCardViewModels(Mapper(xpub)) }
                         .onErrorReturn {
                             listOf(
                                     ErrorCardViewModel(

--- a/app/src/test/java/info/blockchain/challenge/ApiMappingToViewModelTests.kt
+++ b/app/src/test/java/info/blockchain/challenge/ApiMappingToViewModelTests.kt
@@ -19,7 +19,7 @@ class ResultMappingTests {
         val onlyCard = Result(
                 wallet = Wallet(finalBalance = 1234L),
                 transactions = emptyList()
-        ).mapToCardViewModels().single()
+        ).mapToCardViewModels(Mapper("xpub")).single()
         (onlyCard as AccountCardViewModel).finalBalance `should equal` 1234L.satoshiToBtc()
     }
 
@@ -28,7 +28,7 @@ class ResultMappingTests {
         val cards = Result(
                 wallet = Wallet(finalBalance = 12345L),
                 transactions = listOf(Transaction(result = 9999L))
-        ).mapToCardViewModels()
+        ).mapToCardViewModels(Mapper("xpub"))
         cards.size `should be` 2
         (cards.first() as AccountCardViewModel).finalBalance `should equal` 12345L.satoshiToBtc()
         (cards.last() as TransactionVm).value `should equal` 9999L.satoshiToBtc()
@@ -42,7 +42,7 @@ class ResultMappingTests {
                         Transaction(result = 1234L),
                         Transaction(result = 5678L)
                 )
-        ).mapToCardViewModels()
+        ).mapToCardViewModels(Mapper("xpub"))
         cards.size `should be` 3
         (cards[0] as AccountCardViewModel).finalBalance `should equal` 1L.satoshiToBtc()
         (cards[1] as TransactionVm).value `should equal` 1234L.satoshiToBtc()
@@ -57,7 +57,7 @@ class ResultMappingTests {
                         Transaction(timeStamp = 1523447258L),
                         Transaction(timeStamp = 1491868800L)
                 )
-        ).mapToCardViewModels()
+        ).mapToCardViewModels(Mapper("xpub"))
         cards.size `should be` 3
         cards[1] as TransactionVm `should have time stamp` 1523447258_000L
         cards[2] as TransactionVm `should have time stamp` 1491868800_000L

--- a/app/src/test/java/info/blockchain/challenge/TransactionMappingTests.kt
+++ b/app/src/test/java/info/blockchain/challenge/TransactionMappingTests.kt
@@ -2,6 +2,7 @@ package info.blockchain.challenge
 
 import info.blockchain.challenge.api.TXO
 import info.blockchain.challenge.api.Transaction
+import info.blockchain.challenge.api.Xpub
 import info.blockchain.challenge.ui.viewmodel.TransactionCardViewModel
 import info.blockchain.challenge.ui.viewmodel.satoshiToBtc
 import org.amshove.kluent.`should equal`
@@ -11,13 +12,15 @@ class TransactionMappingTests {
 
     @Test
     fun `can map a positive value from an api transaction`() {
-        val transaction: TransactionCardViewModel = Transaction(result = 12345678L).mapToViewModel()
+        val transaction: TransactionCardViewModel =
+                Transaction(result = 12345678L).mapToViewModel(Mapper("xpub"))
         transaction.value `should equal` 12345678L.satoshiToBtc()
     }
 
     @Test
     fun `can map a negative value from an api transaction`() {
-        val transaction: TransactionCardViewModel = Transaction(result = -123456789L).mapToViewModel()
+        val transaction: TransactionCardViewModel =
+                Transaction(result = -123456789L).mapToViewModel(Mapper("xpub"))
         transaction.value `should equal` (-123456789L).satoshiToBtc()
     }
 
@@ -27,7 +30,7 @@ class TransactionAddressMappingTests {
 
     @Test
     fun `empty address`() {
-        val transaction = Transaction().mapToViewModel()
+        val transaction = Transaction().mapToViewModel(Mapper("xpub"))
         transaction.address `should equal` ""
     }
 
@@ -39,20 +42,32 @@ class TransactionAddressMappingTests {
                                 address = "1LgE7gy6Tq9VKbV4FhsLHYA6QrMP8eJXrJ",
                                 xpub = null
                         )
-                )).mapToViewModel()
+                )).mapToViewModel(Mapper("xpub"))
         transaction.address `should equal` "1LgE7gy6Tq9VKbV4FhsLHYA6QrMP8eJXrJ"
     }
 
     @Test
-    fun `single output with xpub`() {
+    fun `single output with xpub that matches the wallet`() {
         val transaction = Transaction(
                 outputs = listOf(
                         TXO(
                                 address = "1AP6CyqYVhEcPMqYCReHoAFVZaVLWAKaJN",
-                                xpub = Any()
+                                xpub = Xpub("Xpub123")
                         )
-                )).mapToViewModel()
+                )).mapToViewModel(Mapper("Xpub123"))
         transaction.address `should equal` ""
+    }
+
+    @Test
+    fun `single output with xpub that doesn't match the wallet`() {
+        val transaction = Transaction(
+                outputs = listOf(
+                        TXO(
+                                address = "1AP6CyqYVhEcPMqYCReHoAFVZaVLWAKaJN",
+                                xpub = Xpub("Xpub123")
+                        )
+                )).mapToViewModel(Mapper("Xpub456"))
+        transaction.address `should equal` "1AP6CyqYVhEcPMqYCReHoAFVZaVLWAKaJN"
     }
 
     @Test
@@ -60,12 +75,25 @@ class TransactionAddressMappingTests {
         val transaction = Transaction(
                 outputs = listOf(
                         TXO(address = "15snCyagJkvpaQGY5hMfcZkgvPDwf6FneP",
-                                xpub = Any()),
+                                xpub = Xpub("Xpub123")),
                         TXO(address = "1NVMi1Ez5uTc3D84cXhNeaksrd4qmYq2rf",
                                 xpub = null)
                 )
-        ).mapToViewModel()
+        ).mapToViewModel(Mapper("Xpub123"))
         transaction.address `should equal` "1NVMi1Ez5uTc3D84cXhNeaksrd4qmYq2rf"
+    }
+
+    @Test
+    fun `two outputs, first with non-matching xpub`() {
+        val transaction = Transaction(
+                outputs = listOf(
+                        TXO(address = "15snCyagJkvpaQGY5hMfcZkgvPDwf6FneP",
+                                xpub = Xpub("Xpub123")),
+                        TXO(address = "1NVMi1Ez5uTc3D84cXhNeaksrd4qmYq2rf",
+                                xpub = null)
+                )
+        ).mapToViewModel(Mapper("Xpub456"))
+        transaction.address `should equal` "15snCyagJkvpaQGY5hMfcZkgvPDwf6FneP"
     }
 
     // Note: this case is to show I have considered it, you might want to show both, or "multiple" but I just show
@@ -79,7 +107,7 @@ class TransactionAddressMappingTests {
                         TXO(address = "195Ucqi4Rgx319LM8SEz8a7UFoMpbD7mid",
                                 xpub = null)
                 )
-        ).mapToViewModel()
+        ).mapToViewModel(Mapper("xpub"))
         transaction.address `should equal` "1Q2XkxYnd56Saz6GnrJuuxhFDWNj6BVHrn"
     }
 


### PR DESCRIPTION
As challenge #1

> A “change” output easily spotted because the output has an “xpub” -> “m” field which matches the xPub parameter in the multiaddress call

I was just checking non-null of xpub json object.